### PR TITLE
fix(ice): TCP read/write split and WHEP answerer media path

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,38 @@
+## Summary
+
+Fix ICE-TCP media transport and WHEP/answerer outbound RTP for browsers that connect over `TCP/TLS/RTP/SAVPF`.
+
+Validated with Monibuca WHEP pull (ICE-TCP only): DTLS completes, SRTP flows, browser `framesDecoded > 0`.
+
+### Changes
+
+1. **ICE TCP read/write split** (`transports/ice/mod.rs`)
+   - Split `TcpStream` into owned read/write halves so outbound DTLS/SRTP writes do not block the read loop on the same mutex.
+   - RFC 4571 framing via `tcp_write_all` for STUN/DTLS/RTP on TCP.
+
+2. **DTLS flight batching over TCP** (`transports/ice/conn.rs`, `transports/dtls/mod.rs`)
+   - `send_dtls_record_batch`: frame multiple DTLS records and write in one syscall so Chrome sees complete handshake flights.
+   - Unbounded handshake channel to avoid dropping inbound records during setup.
+
+3. **abs-send-time extension non-fatal** (`transports/rtp.rs`)
+   - If `set_extension` fails (small payloads), log and continue sending RTP instead of aborting the whole packet.
+
+4. **WHEP answerer transceiver reuse** (`peer_connection.rs`)
+   - `add_track_with_stream_id` reuses the offer-created transceiver (with MID) instead of adding a second same-kind transceiver.
+
+5. **DTLS runner lifecycle** (`peer_connection.rs`)
+   - Spawn DTLS handshake loop before flushing buffered packets to avoid try_send races.
+
+6. **ICE-TCP nomination / keepalive** (`transports/ice/mod.rs`)
+   - `nudge_passive_tcp_nomination` for controlled peers with inbound passive TCP.
+   - Longer disconnect threshold when TCP is selected (recv-only WHEP may not send STUN immediately).
+
+## Test plan
+
+- [x] `cargo build`
+- [x] `cargo test --lib` (396 tests)
+- [x] Manual: Monibuca WHEP ICE-TCP pull, Chrome `framesDecoded > 0`
+
+## Related
+
+Monibuca notes: `docs/webrtc-ice-tcp-whep.md` in [Monibuca/v6-dev](https://github.com/Monibuca/Enterprise) (vendor path `third_party/rustrtc`).

--- a/src/peer_connection.rs
+++ b/src/peer_connection.rs
@@ -33,7 +33,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::{broadcast, mpsc, watch};
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use async_trait::async_trait;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -625,8 +625,25 @@ impl PeerConnection {
             crate::media::frame::MediaKind::Audio => MediaKind::Audio,
             crate::media::frame::MediaKind::Video => MediaKind::Video,
         };
-        // Track-based transceivers always use Audio or Video media kinds
-        let transceiver = self.add_transceiver(kind, TransceiverDirection::SendRecv);
+        // Reuse a transceiver created from the remote offer (WHEP/answerer path).
+        // Otherwise add_track would create a second same-kind transceiver without the
+        // offer MID, and create_answer would bind the offer m-line to the empty one.
+        let transceiver = {
+            let list = self.inner.transceivers.lock();
+            if let Some(existing) = list.iter().find(|t| {
+                t.kind() == kind && t.mid().is_some() && t.sender.lock().is_none()
+            }) {
+                info!(
+                    "add_track: reusing offer transceiver kind={:?} mid={:?}",
+                    kind,
+                    existing.mid()
+                );
+                existing.clone()
+            } else {
+                drop(list);
+                self.add_transceiver(kind, TransceiverDirection::SendRecv)
+            }
+        };
         let ssrc = (*transceiver.sender_ssrc.lock())
             .unwrap_or_else(|| self.inner.ssrc_generator.fetch_add(1, Ordering::Relaxed));
 
@@ -1558,6 +1575,10 @@ impl PeerConnection {
         .await
         .map_err(|e| RtcError::Internal(format!("DTLS failed: {}", e)))?;
 
+        // Start the handshake loop before flushing buffered packets so inbound
+        // DTLS records are not dropped on the try_send race.
+        let mut dtls_runner_task = tokio::spawn(dtls_runner);
+
         // DTLS receiver is now registered (inside DtlsTransport::new),
         // safe to set data receiver and flush buffered packets.
         self.inner
@@ -1615,8 +1636,6 @@ impl PeerConnection {
         let inner_weak = Arc::downgrade(&self.inner);
         let stats_collector = self.inner.stats_collector.clone();
 
-        let mut dtls_runner: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(dtls_runner);
-
         let inner_weak_dc = inner_weak.clone();
         let dc_listener = async move {
             while let Some(dc) = dc_rx.recv().await {
@@ -1652,7 +1671,6 @@ impl PeerConnection {
                     let combined: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
                         tokio::select! {
                             _ = rtcp_loop => {},
-                            _ = dtls_runner => {},
                             _ = sctp_runner => {},
                             _ = dc_listener => {},
                             _ = pair_monitor => {},
@@ -1667,8 +1685,10 @@ impl PeerConnection {
             }
 
             tokio::select! {
-                _ = &mut dtls_runner => {
-                     return Err(RtcError::Internal("DTLS runner stopped unexpectedly".into()));
+                res = &mut dtls_runner_task => {
+                    if let Err(e) = res {
+                        return Err(RtcError::Internal(format!("DTLS runner panicked: {e}")));
+                    }
                 }
                 _ = &mut sctp_runner => {
                      return Err(RtcError::Internal("SCTP runner stopped unexpectedly".into()));
@@ -1823,6 +1843,10 @@ impl PeerConnection {
             match crate::srtp::SrtpSession::new(profile, tx_keying, rx_keying) {
                 Ok(session) => {
                     rtp_transport.start_srtp(session);
+                    info!(
+                        "setup_srtp: SRTP session ready (is_client={}, profile={:?})",
+                        is_client, profile
+                    );
 
                     let transceivers = self.inner.transceivers.lock();
                     for t in transceivers.iter() {
@@ -1855,12 +1879,12 @@ impl PeerConnection {
                     *self.inner.rtp_transport.lock() = Some(rtp_transport.clone());
                 }
                 Err(e) => {
-                    debug!("Failed to create SRTP session: {}", e);
+                    warn!("Failed to create SRTP session: {}", e);
                 }
             }
         } else {
-            debug!(
-                "Failed to export keying material - DTLS state: {}",
+            warn!(
+                "Failed to export DTLS-SRTP keying material - DTLS state: {}",
                 dtls.get_state()
             );
         }
@@ -3151,6 +3175,8 @@ async fn run_ice_dtls_loop(
         match ice_state {
             crate::transports::ice::IceTransportState::Connected
             | crate::transports::ice::IceTransportState::Completed => {
+                ice_transport.nudge_passive_tcp_nomination();
+                tokio::task::yield_now().await;
                 // Wait for ICE nomination to complete before starting DTLS.
                 // This prevents a race where DTLS and the USE-CANDIDATE binding check
                 // compete for the same UDP socket, causing spurious nomination timeouts.
@@ -5037,8 +5063,13 @@ impl RtpSender {
         let _ = self.transport_change_tx.send(generation);
 
         *self.transport.lock() = Some(transport.clone());
+        let track_id = self.track_id.clone();
         let track = self.track.clone();
         let ssrc = self.ssrc;
+        info!(
+            "RtpSender: spawning send loop track_id={} ssrc={}",
+            track_id, ssrc
+        );
         let params_lock = self.params.clone();
         let stop_rx = self.stop_tx.clone();
         let mut transport_change_rx = self.transport_change_tx.subscribe();
@@ -5053,6 +5084,7 @@ impl RtpSender {
 
         tokio::spawn(async move {
             let mut sequence_number = next_seq.load(Ordering::SeqCst);
+            let mut logged_first_sample = false;
             let mut last_source_ts: Option<u32> = None;
             let mut timestamp_offset = random_u32(); // Start with random offset
             // Delay the first SR so the initial RTP burst is not immediately followed by RTCP
@@ -5124,6 +5156,13 @@ impl RtpSender {
                         }
                         match res {
                             Ok(mut sample) => {
+                                if !logged_first_sample {
+                                    logged_first_sample = true;
+                                    info!(
+                                        "RtpSender: first sample dequeued ssrc={} track_id={}",
+                                        ssrc, track_id
+                                    );
+                                }
                                 let payload_type = {
                                     let p = params_lock.lock();
                                     p.payload_type
@@ -5203,9 +5242,20 @@ impl RtpSender {
                                 let packet_timestamp = packet.header.timestamp;
 
                                 if let Err(e) = transport.send_rtp(packet).await {
-                                    debug!("Failed to send RTP: {}", e);
+                                    let n = packets_sent.load(Ordering::Relaxed);
+                                    if n < 5 {
+                                        warn!("RtpSender: failed to send RTP (ssrc={}): {}", ssrc, e);
+                                    } else {
+                                        debug!("Failed to send RTP: {}", e);
+                                    }
                                 } else {
-                                    packets_sent.fetch_add(1, Ordering::Relaxed);
+                                    let n = packets_sent.fetch_add(1, Ordering::Relaxed) + 1;
+                                    if n == 1 {
+                                        info!(
+                                            "RtpSender: first RTP packet sent on wire ssrc={} track_id={}",
+                                            ssrc, track_id
+                                        );
+                                    }
                                     octets_sent.fetch_add(payload_len, Ordering::Relaxed);
                                     last_rtp_timestamp.store(packet_timestamp, Ordering::Relaxed);
                                 }

--- a/src/transports/dtls/mod.rs
+++ b/src/transports/dtls/mod.rs
@@ -39,7 +39,7 @@ use self::handshake::{
 };
 use self::record::{ContentType, DtlsRecord, ProtocolVersion};
 use crate::transports::ice::conn::IceConn;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 pub fn generate_certificate() -> Result<Certificate> {
     let cert = generate_simple_self_signed(vec!["localhost".to_string()])?;
@@ -176,7 +176,7 @@ struct DtlsInner {
     state: Arc<Mutex<DtlsState>>,
     state_tx: tokio::sync::watch::Sender<DtlsState>,
     state_rx: tokio::sync::watch::Receiver<DtlsState>,
-    handshake_rx_feeder: mpsc::Sender<Bytes>,
+    handshake_rx_feeder: mpsc::UnboundedSender<Bytes>,
     write_seq: AtomicU64,
     write_epoch: AtomicU16,
     is_client: bool,
@@ -239,7 +239,7 @@ impl DtlsTransport {
         impl std::future::Future<Output = ()> + Send,
     )> {
         let (incoming_data_tx, incoming_data_rx) = mpsc::unbounded_channel();
-        let (handshake_rx_feeder, handshake_rx) = mpsc::channel(2000);
+        let (handshake_rx_feeder, handshake_rx) = mpsc::unbounded_channel();
         let (state_tx, state_rx) = tokio::sync::watch::channel(DtlsState::New);
 
         let inner = Arc::new(DtlsInner {
@@ -377,11 +377,9 @@ impl DtlsTransport {
     pub fn export_keying_material(&self, label: &str, len: usize) -> Result<Vec<u8>> {
         let state = self.inner.state.lock();
         if let DtlsState::Connected(crypto, _) = &*state {
-            let seed = [
-                crypto.keys.client_random.as_slice(),
-                crypto.keys.server_random.as_slice(),
-            ]
-            .concat();
+            // RFC 5764: seed = client_random || server_random (in that order).
+            let seed = [crypto.keys.client_random.as_slice(), crypto.keys.server_random.as_slice()]
+                .concat();
             prf_sha256(&crypto.keys.master_secret, label.as_bytes(), &seed, len)
         } else {
             Err(anyhow::anyhow!("DTLS not connected"))
@@ -397,15 +395,11 @@ impl Drop for DtlsTransport {
 
 impl DtlsInner {
     async fn handle_retransmit(&self, ctx: &HandshakeContext, _is_client: bool) {
-        // Scope the lock to avoid holding it across the async send
-        {
-            let state = self.state.lock();
-            if *state != DtlsState::Handshaking {
-                return;
-            }
+        if *self.state.lock() != DtlsState::Handshaking {
+            return;
         }
-        if let Some(buf) = &ctx.last_flight_buffer {
-            if let Err(e) = self.conn.send(buf).await {
+        if let Some(records) = &ctx.last_flight_records {
+            if let Err(e) = self.conn.send_dtls_record_batch(records).await {
                 if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
                     match io_err.kind() {
                         std::io::ErrorKind::HostUnreachable
@@ -555,7 +549,12 @@ impl DtlsInner {
     ) -> Result<()> {
         match content_type {
             ContentType::ChangeCipherSpec => {
-                trace!("Received ChangeCipherSpec — encryption is handled per-record via epoch field. Epoch increments post-CCS by sender; try_decrypt_record auto-detects based on epoch > 0.");
+                trace!(
+                    "Received ChangeCipherSpec, advancing read_epoch {} -> {}",
+                    ctx.read_epoch,
+                    ctx.read_epoch.saturating_add(1)
+                );
+                ctx.read_epoch = ctx.read_epoch.saturating_add(1);
             }
             ContentType::ApplicationData => {
                 let _ = incoming_data_tx.send(payload);
@@ -807,8 +806,8 @@ impl DtlsInner {
         }
 
         if ctx.server_random.is_some() {
-            if let Some(flight) = &ctx.last_flight_buffer {
-                if let Err(e) = self.conn.send(flight).await {
+            if let Some(records) = &ctx.last_flight_records {
+                if let Err(e) = self.conn.send_dtls_record_batch(records).await {
                     if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
                         match io_err.kind() {
                             std::io::ErrorKind::HostUnreachable
@@ -942,18 +941,15 @@ impl DtlsInner {
         handshake_msg.encode(&mut buf);
         ctx.handshake_messages.extend_from_slice(&buf);
 
-        let mut flight_buffer = Vec::new();
+        let mut flight_records: Vec<Vec<u8>> = Vec::new();
 
-        let buf = self
-            .send_handshake_message(
-                handshake_msg,
-                ctx.epoch,
-                &mut ctx.sequence_number,
-                None,
-                is_client,
-            )
-            .await?;
-        flight_buffer.extend_from_slice(&buf);
+        flight_records.push(self.build_handshake_record(
+            handshake_msg,
+            ctx.epoch,
+            &mut ctx.sequence_number,
+            None,
+            is_client,
+        )?);
         ctx.message_seq += 1;
 
         // Send Certificate
@@ -977,16 +973,13 @@ impl DtlsInner {
         handshake_msg.encode(&mut buf);
         ctx.handshake_messages.extend_from_slice(&buf);
 
-        let buf = self
-            .send_handshake_message(
-                handshake_msg,
-                ctx.epoch,
-                &mut ctx.sequence_number,
-                None,
-                is_client,
-            )
-            .await?;
-        flight_buffer.extend_from_slice(&buf);
+        flight_records.push(self.build_handshake_record(
+            handshake_msg,
+            ctx.epoch,
+            &mut ctx.sequence_number,
+            None,
+            is_client,
+        )?);
         ctx.message_seq += 1;
 
         // Send ServerKeyExchange
@@ -1039,16 +1032,13 @@ impl DtlsInner {
         handshake_msg.encode(&mut buf);
         ctx.handshake_messages.extend_from_slice(&buf);
 
-        let buf = self
-            .send_handshake_message(
-                handshake_msg,
-                ctx.epoch,
-                &mut ctx.sequence_number,
-                None,
-                is_client,
-            )
-            .await?;
-        flight_buffer.extend_from_slice(&buf);
+        flight_records.push(self.build_handshake_record(
+            handshake_msg,
+            ctx.epoch,
+            &mut ctx.sequence_number,
+            None,
+            is_client,
+        )?);
         ctx.message_seq += 1;
 
         // Send ServerHelloDone
@@ -1069,19 +1059,19 @@ impl DtlsInner {
         handshake_msg.encode(&mut buf);
         ctx.handshake_messages.extend_from_slice(&buf);
 
-        let buf = self
-            .send_handshake_message(
-                handshake_msg,
-                ctx.epoch,
-                &mut ctx.sequence_number,
-                None,
-                is_client,
-            )
-            .await?;
-        flight_buffer.extend_from_slice(&buf);
+        flight_records.push(self.build_handshake_record(
+            handshake_msg,
+            ctx.epoch,
+            &mut ctx.sequence_number,
+            None,
+            is_client,
+        )?);
         ctx.message_seq += 1;
 
-        ctx.last_flight_buffer = Some(flight_buffer);
+        self.conn
+            .send_dtls_record_batch(&flight_records)
+            .await?;
+        ctx.last_flight_records = Some(flight_records);
 
         Ok(())
     }
@@ -1219,7 +1209,7 @@ impl DtlsInner {
             // Add Client's Finished to transcript
             ctx.handshake_messages.extend_from_slice(raw_msg);
 
-            let mut flight_buffer = Vec::new();
+            let mut flight_records: Vec<Vec<u8>> = Vec::new();
 
             // Send ChangeCipherSpec
             let record = DtlsRecord {
@@ -1229,12 +1219,10 @@ impl DtlsInner {
                 sequence_number: ctx.sequence_number,
                 payload: Bytes::from_static(&[1]),
             };
-            // sequence_number increment is not needed as we reset it below
 
             let mut buf = BytesMut::new();
             record.encode(&mut buf);
-            self.conn.send(&buf).await?;
-            flight_buffer.extend_from_slice(&buf);
+            flight_records.push(buf.to_vec());
 
             ctx.epoch += 1;
             ctx.sequence_number = 0;
@@ -1268,17 +1256,19 @@ impl DtlsInner {
             handshake_msg.encode(&mut buf);
             ctx.handshake_messages.extend_from_slice(&buf);
 
-            let buf = self
-                .send_handshake_message(
+            flight_records.push(
+                self.build_handshake_record(
                     handshake_msg,
                     ctx.epoch,
                     &mut ctx.sequence_number,
                     ctx.session_keys.as_ref(),
                     is_client,
-                )
+                )?,
+            );
+            self.conn
+                .send_dtls_record_batch(&flight_records)
                 .await?;
-            flight_buffer.extend_from_slice(&buf);
-            ctx.last_flight_buffer = Some(flight_buffer);
+            ctx.last_flight_records = Some(flight_records);
             // message_seq += 1; // End of handshake
 
             if let Some(keys) = &ctx.session_keys {
@@ -1288,6 +1278,7 @@ impl DtlsInner {
                 self.write_epoch.store(ctx.epoch, Ordering::SeqCst);
                 self.write_seq.store(ctx.sequence_number, Ordering::SeqCst);
                 let _ = self.state_tx.send(state);
+                info!("DTLS handshake complete (server role)");
                 // Clear ephemeral secret as handshake is complete
                 ctx.local_secret = None;
             } else {
@@ -1385,15 +1376,15 @@ impl DtlsInner {
             ctx.handshake_messages.extend_from_slice(&buf);
 
             let buf = self
-                .send_handshake_message(
+                .build_handshake_record(
                     handshake_msg,
                     ctx.epoch,
                     &mut ctx.sequence_number,
                     None,
                     is_client,
-                )
-                .await?;
-            ctx.last_flight_buffer = Some(buf);
+                )?;
+            self.conn.send(&buf).await?;
+            ctx.last_flight_records = Some(vec![buf]);
             ctx.message_seq += 1;
             // After sending a new ClientHello in response to HelloVerifyRequest,
             // the server will restart its own handshake message_seq counter.
@@ -1606,7 +1597,7 @@ impl DtlsInner {
         ctx.session_crypto = Some(create_session_crypto(keys.clone())?);
         ctx.session_keys = Some(keys);
 
-        let mut flight_buffer = Vec::new();
+        let mut flight_records: Vec<Vec<u8>> = Vec::new();
 
         // Send ChangeCipherSpec
         let record = DtlsRecord {
@@ -1619,8 +1610,7 @@ impl DtlsInner {
 
         let mut buf = BytesMut::new();
         record.encode(&mut buf);
-        self.conn.send(&buf).await?;
-        flight_buffer.extend_from_slice(&buf);
+        flight_records.push(buf.to_vec());
 
         ctx.epoch += 1;
         ctx.sequence_number = 0;
@@ -1647,17 +1637,19 @@ impl DtlsInner {
         handshake_msg.encode(&mut buf);
         ctx.handshake_messages.extend_from_slice(&buf);
 
-        let buf = self
-            .send_handshake_message(
+        flight_records.push(
+            self.build_handshake_record(
                 handshake_msg,
                 ctx.epoch,
                 &mut ctx.sequence_number,
                 ctx.session_keys.as_ref(),
                 is_client,
-            )
+            )?,
+        );
+        self.conn
+            .send_dtls_record_batch(&flight_records)
             .await?;
-        flight_buffer.extend_from_slice(&buf);
-        ctx.last_flight_buffer = Some(flight_buffer);
+        ctx.last_flight_records = Some(flight_records);
         ctx.message_seq += 1;
 
         Ok(())
@@ -1667,7 +1659,7 @@ impl DtlsInner {
         certificate: Certificate,
         is_client: bool,
         incoming_data_tx: mpsc::UnboundedSender<Bytes>,
-        mut handshake_rx: mpsc::Receiver<Bytes>,
+        mut handshake_rx: mpsc::UnboundedReceiver<Bytes>,
         close_rx: Arc<tokio::sync::Notify>,
     ) -> Result<()> {
         *self.state.lock() = DtlsState::Handshaking;
@@ -1725,7 +1717,7 @@ impl DtlsInner {
                 )
                 .await?;
             trace!("ClientHello sent ({} bytes)", buf.len());
-            ctx.last_flight_buffer = Some(buf);
+            ctx.last_flight_records = Some(vec![buf]);
             ctx.message_seq += 1;
         }
 
@@ -1780,7 +1772,7 @@ impl DtlsInner {
         }
     }
 
-    async fn send_handshake_message(
+    fn build_handshake_record(
         &self,
         msg: HandshakeMessage,
         epoch: u16,
@@ -1825,6 +1817,24 @@ impl DtlsInner {
 
         let mut buf = BytesMut::new();
         record.encode(&mut buf);
+        Ok(buf.to_vec())
+    }
+
+    async fn send_handshake_message(
+        &self,
+        msg: HandshakeMessage,
+        epoch: u16,
+        sequence_number: &mut u64,
+        session_keys: Option<&SessionKeys>,
+        is_client: bool,
+    ) -> Result<Vec<u8>> {
+        let buf = self.build_handshake_record(
+            msg,
+            epoch,
+            sequence_number,
+            session_keys,
+            is_client,
+        )?;
         if let Err(e) = self.conn.send(&buf).await {
             if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
                 match io_err.kind() {
@@ -1865,9 +1875,8 @@ use std::net::SocketAddr;
 #[async_trait::async_trait]
 impl PacketReceiver for DtlsTransport {
     async fn receive(&self, packet: Bytes, _addr: SocketAddr) {
-        match self.inner.handshake_rx_feeder.try_send(packet) {
-            Ok(_) => {}
-            Err(_) => {}
+        if self.inner.handshake_rx_feeder.send(packet).is_err() {
+            warn!("DTLS handshake channel closed, dropping inbound packet");
         }
     }
 }
@@ -2080,7 +2089,10 @@ fn encrypt_record(
 
 struct HandshakeContext {
     sequence_number: u64,
+    /// Outbound DTLS record epoch (write epoch).
     epoch: u16,
+    /// Inbound DTLS record epoch (read epoch); advanced on peer ChangeCipherSpec only.
+    read_epoch: u16,
     message_seq: u16,
     recv_message_seq: u16,
     /// Set after processing a HelloVerifyRequest so that the next server
@@ -2088,7 +2100,7 @@ struct HandshakeContext {
     /// RFC 6347 §4.2.1 says the server should restart at 0, but some
     /// implementations (e.g. webrtc-dtls) continue from the HVR seq + 1.
     post_hvr: bool,
-    last_flight_buffer: Option<Vec<u8>>,
+    last_flight_records: Option<Vec<Vec<u8>>>,
     incomplete_handshake: BytesMut,
     incomplete_msg_seq: u16,
     local_secret: Option<EphemeralSecret>,
@@ -2116,10 +2128,11 @@ impl HandshakeContext {
         Self {
             sequence_number: 0,
             epoch: 0,
+            read_epoch: 0,
             message_seq: 0,
             recv_message_seq: 0,
             post_hvr: false,
-            last_flight_buffer: None,
+            last_flight_records: None,
             incomplete_handshake: BytesMut::new(),
             incomplete_msg_seq: 0,
             local_secret: Some(local_secret),

--- a/src/transports/ice/conn.rs
+++ b/src/transports/ice/conn.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use tokio::sync::watch;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// Per-source-address state tracked during the latching probation period.
 ///
@@ -214,10 +214,26 @@ impl IceConn {
             if remote.port() == 0 {
                 return Err(anyhow::anyhow!("Remote address not set"));
             }
-            // tracing::trace!("IceConn: sending {} bytes to {}", buf.len(), remote);
             let n = socket.send_to(buf, remote).await?;
-            self.tx_packets.fetch_add(1, Ordering::Relaxed);
-            self.tx_bytes.fetch_add(n as u64, Ordering::Relaxed);
+            let tx_pkts = self.tx_packets.fetch_add(1, Ordering::Relaxed) + 1;
+            let tx_bytes = self.tx_bytes.fetch_add(n as u64, Ordering::Relaxed) + n as u64;
+            let is_rtp = buf.first().is_some_and(|b| (128..192).contains(b));
+            // RTP/RTCP might not be easy to identify reliably from the first byte.
+            // For TCP ICE debugging we log the first few outbound packets from the RTP
+            // path so we can confirm on-wire packet layout.
+            if tx_pkts <= 50 || (is_rtp && tx_pkts % 50 == 0) {
+                info!(
+                    label = ?self.label,
+                    socket = %socket.diag(),
+                    remote = %remote,
+                    len = buf.len(),
+                    is_rtp,
+                    first_byte = buf.first().copied().unwrap_or(0),
+                    tx_pkts,
+                    tx_bytes,
+                    "IceConn: sent outbound packet"
+                );
+            }
             Ok(n)
         } else {
             // Fallback: try to update if None
@@ -228,14 +244,95 @@ impl IceConn {
                 if remote.port() == 0 {
                     return Err(anyhow::anyhow!("Remote address not set"));
                 }
-                // tracing::trace!("IceConn: sending {} bytes to {}", buf.len(), remote);
                 let n = socket.send_to(buf, remote).await?;
-                self.tx_packets.fetch_add(1, Ordering::Relaxed);
-                self.tx_bytes.fetch_add(n as u64, Ordering::Relaxed);
+                let tx_pkts = self.tx_packets.fetch_add(1, Ordering::Relaxed) + 1;
+                let tx_bytes = self.tx_bytes.fetch_add(n as u64, Ordering::Relaxed) + n as u64;
+                let is_rtp = buf.first().is_some_and(|b| (128..192).contains(b));
+                if tx_pkts <= 50 || (is_rtp && tx_pkts % 50 == 0) {
+                    info!(
+                        label = ?self.label,
+                        socket = %socket.diag(),
+                        remote = %remote,
+                        len = buf.len(),
+                        is_rtp,
+                        first_byte = buf.first().copied().unwrap_or(0),
+                        tx_pkts,
+                        tx_bytes,
+                        fallback_socket = true,
+                        "IceConn: sent outbound packet"
+                    );
+                }
                 Ok(n)
             } else {
                 tracing::warn!("IceConn: send failed - no selected socket");
                 Err(anyhow::anyhow!("No selected socket"))
+            }
+        }
+    }
+
+    /// Send multiple DTLS records. On TCP, each record is RFC 4571-framed and all
+    /// frames are written in one syscall (avoids Chrome seeing a partial flight).
+    pub async fn send_dtls_record_batch(&self, records: &[Vec<u8>]) -> Result<usize> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        if should_drop_packet() {
+            return Ok(records.iter().map(|r| r.len()).sum());
+        }
+
+        let remote = *self.remote_addr.read();
+        if remote.port() == 0 {
+            return Err(anyhow::anyhow!("Remote address not set"));
+        }
+
+        let socket_rx = self.socket_rx.clone();
+        let mut socket_opt = socket_rx.borrow().clone();
+        if socket_opt.is_none() {
+            let mut rx = self.socket_rx.clone();
+            socket_opt = rx.borrow_and_update().clone();
+        }
+
+        let Some(socket) = socket_opt else {
+            tracing::warn!("IceConn: send_dtls_record_batch failed - no selected socket");
+            return Err(anyhow::anyhow!("No selected socket"));
+        };
+
+        let total_payload: usize = records.iter().map(|r| r.len()).sum();
+        let prev_tx_pkts = self.tx_packets.load(Ordering::Relaxed);
+        let tx_pkts = self.tx_packets.fetch_add(records.len() as u64, Ordering::Relaxed) + records.len() as u64;
+
+        match &socket {
+            IceSocketWrapper::TcpStream(_, write, _) => {
+                let mut framed = Vec::new();
+                for record in records {
+                    if record.len() > 0xFFFF {
+                        return Err(anyhow::anyhow!("DTLS record too large for TCP framing"));
+                    }
+                    framed.extend_from_slice(&(record.len() as u16).to_be_bytes());
+                    framed.extend_from_slice(record);
+                }
+                super::tcp_write_all(write, &framed).await?;
+                let tx_bytes = self.tx_bytes.fetch_add(framed.len() as u64, Ordering::Relaxed) + framed.len() as u64;
+                if prev_tx_pkts < 5 {
+                    info!(
+                        label = ?self.label,
+                        socket = %socket.diag(),
+                        remote = %remote,
+                        records = records.len(),
+                        framed_len = framed.len(),
+                        tx_pkts,
+                        tx_bytes,
+                        "IceConn: sent outbound DTLS record batch"
+                    );
+                }
+                Ok(total_payload)
+            }
+            _ => {
+                let mut total = 0usize;
+                for record in records {
+                    total += self.send(record).await?;
+                }
+                Ok(total)
             }
         }
     }
@@ -292,13 +389,27 @@ impl PacketReceiver for IceConn {
         self.rx_packets.fetch_add(1, Ordering::Relaxed);
         self.rx_bytes
             .fetch_add(packet.len() as u64, Ordering::Relaxed);
+        let rx_pkts = self.rx_packets.load(Ordering::Relaxed);
 
         let first_byte = packet[0];
         // Scope for read lock
         let current_remote = *self.remote_addr.read();
 
-        // If remote_addr is unspecified (port 0), accept and update
-        if current_remote.port() == 0 {
+        // Passive ICE-TCP: the browser often omits TCP candidates in SDP and
+        // connects inbound. Latch the real peer from the first packet on the
+        // accepted stream so DTLS/RTP replies use the correct destination.
+        let socket_is_inbound_tcp = {
+            let socket_rx = self.socket_rx.clone();
+            matches!(
+                socket_rx.borrow().as_ref(),
+                Some(IceSocketWrapper::TcpStream(_, _, _))
+            )
+        };
+        if socket_is_inbound_tcp
+            && (current_remote.port() == 0 || current_remote != addr)
+        {
+            *self.remote_addr.write() = addr;
+        } else if current_remote.port() == 0 {
             *self.remote_addr.write() = addr;
         } else if addr != current_remote {
             // Note: We no longer automatically switch the remote address just by receiving
@@ -314,6 +425,15 @@ impl PacketReceiver for IceConn {
 
         if (20..64).contains(&first_byte) {
             // DTLS
+            if rx_pkts <= 3 {
+                info!(
+                    label = ?self.label,
+                    from = %addr,
+                    len = packet.len(),
+                    rx_pkts,
+                    "IceConn: received DTLS packet"
+                );
+            }
             let receiver = {
                 let rx_lock = self.dtls_receiver.read();
                 if let Some(rx) = &*rx_lock {
@@ -332,6 +452,15 @@ impl PacketReceiver for IceConn {
         } else if (128..192).contains(&first_byte) {
             // RTP / RTCP
             let is_rtcp = packet.len() >= 2 && (200..=211).contains(&packet[1]);
+            if !is_rtcp && rx_pkts <= 5 {
+                info!(
+                    label = ?self.label,
+                    from = %addr,
+                    len = packet.len(),
+                    rx_pkts,
+                    "IceConn: received RTP packet"
+                );
+            }
 
             if self.latch_on_rtp.load(Ordering::Relaxed) {
                 if is_rtcp {

--- a/src/transports/ice/mod.rs
+++ b/src/transports/ice/mod.rs
@@ -26,11 +26,10 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
-use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream, UdpSocket, lookup_host};
 use tokio::sync::{Mutex, broadcast, mpsc, oneshot, watch};
 use tokio::time::timeout;
-use tracing::{debug, instrument, trace};
+use tracing::{debug, info, instrument, trace};
 
 #[cfg(any(test, feature = "simulator"))]
 use self::stun::random_u32;
@@ -212,8 +211,13 @@ impl IceTransportRunner {
                             IceSocketWrapper::TcpListener(l) => {
                                 read_futures.push(Box::pin(Self::run_tcp_listen_loop(l, self.inner.clone())));
                             }
-                            IceSocketWrapper::TcpStream(s, peer) => {
-                                read_futures.push(Box::pin(Self::run_tcp_read_loop(s, peer, self.inner.clone())));
+                            IceSocketWrapper::TcpStream(read, write, peer) => {
+                                read_futures.push(Box::pin(Self::run_tcp_read_loop(
+                                    read,
+                                    write,
+                                    peer,
+                                    self.inner.clone(),
+                                )));
                             }
                             IceSocketWrapper::Turn(c, addr) => {
                                 read_futures.push(Box::pin(Self::run_turn_read_loop(c, addr, self.inner.clone())));
@@ -394,11 +398,7 @@ impl IceTransportRunner {
                     match accept_res {
                         Ok((stream, peer_addr)) => {
                             trace!("TCP accepted connection from {}", peer_addr);
-                            if let Err(e) = stream.set_nodelay(true) {
-                                debug!("TCP set_nodelay failed: {}", e);
-                            }
-                            let stream = Arc::new(Mutex::new(stream));
-                            let wrapper = IceSocketWrapper::TcpStream(stream.clone(), peer_addr);
+                            let wrapper = split_tcp_stream(stream, peer_addr);
                             inner.gatherer.store_tcp_stream(local_addr, wrapper.clone());
                             let _ = inner.gatherer.socket_tx.send(wrapper);
                         }
@@ -419,31 +419,24 @@ impl IceTransportRunner {
     }
 
     async fn run_tcp_read_loop(
-        stream: Arc<Mutex<TcpStream>>,
+        read: Arc<Mutex<TcpReadHalf>>,
+        write: Arc<Mutex<TcpWriteHalf>>,
         peer_addr: SocketAddr,
         inner: Arc<IceTransportInner>,
     ) {
-        use tokio::io::AsyncReadExt;
-        let mut buf = [0u8; 1500];
+        let mut buf = [0u8; 65_535];
         let mut state_rx = inner.state.subscribe();
-        let sender = IceSocketWrapper::TcpStream(stream.clone(), peer_addr);
+        let sender = IceSocketWrapper::TcpStream(read, write, peer_addr);
         trace!("TCP read loop started for peer {}", peer_addr);
         loop {
             tokio::select! {
-                result = async {
-                    let mut s = stream.lock().await;
-                    s.read(&mut buf).await
-                } => {
+                result = sender.recv_from(&mut buf) => {
                     match result {
-                        Ok(0) => {
-                            trace!("TCP connection closed by peer {}", peer_addr);
-                            break;
-                        }
-                        Ok(len) => {
+                        Ok((len, addr)) => {
                             if len > 0 {
                                 handle_packet(
                                     &buf[..len],
-                                    peer_addr,
+                                    addr,
                                     inner.clone(),
                                     sender.clone(),
                                 )
@@ -451,7 +444,7 @@ impl IceTransportRunner {
                             }
                         }
                         Err(e) => {
-                            debug!("TCP read error from {}: {}", peer_addr, e);
+                            debug!("TCP recv error from {}: {}", peer_addr, e);
                             break;
                         }
                     }
@@ -475,9 +468,22 @@ impl IceTransportRunner {
             if inner.config.transport_mode == crate::TransportMode::WebRtc {
                 let elapsed = inner.last_received.lock().elapsed();
                 let ice_conn_timeout = inner.config.ice_connection_timeout;
+                let tcp_selected = inner
+                    .selected_pair
+                    .lock()
+                    .as_ref()
+                    .map(|pair| pair.local.transport == "tcp")
+                    .unwrap_or(false);
+                // ICE-TCP recv-only peers (e.g. WHEP) may not send STUN for several seconds
+                // while DTLS/SRTP comes up; do not flap to Disconnected on the UDP 5s heuristic.
+                let disconnect_threshold = if tcp_selected {
+                    ice_conn_timeout.saturating_sub(Duration::from_secs(1))
+                } else {
+                    Duration::from_secs(5)
+                };
                 if elapsed > ice_conn_timeout {
                     let _ = inner.state.send(IceTransportState::Failed);
-                } else if elapsed > Duration::from_secs(5) {
+                } else if elapsed > disconnect_threshold {
                     if state != IceTransportState::Disconnected {
                         let _ = inner.state.send(IceTransportState::Disconnected);
                     }
@@ -489,7 +495,12 @@ impl IceTransportRunner {
             // Send Keepalive
             let pair_opt = inner.selected_pair.lock().clone();
             if let Some(pair) = pair_opt {
-                if let Some(socket) = resolve_socket(inner, &pair) {
+                let socket = inner
+                    ._socket_rx_keeper
+                    .borrow()
+                    .clone()
+                    .or_else(|| resolve_socket(inner, &pair));
+                if let Some(socket) = socket {
                     let tx_id = random_bytes::<12>();
                     let mut msg = StunMessage::binding_request(tx_id, Some("rustrtc"));
 
@@ -835,6 +846,29 @@ impl IceTransport {
     pub fn subscribe_nomination_complete(&self) -> watch::Receiver<Option<bool>> {
         self.inner.nomination_complete.subscribe()
     }
+
+    /// When the controlling peer has no local TCP candidates it may connect inbound
+    /// without sending USE-CANDIDATE. Complete nomination once a passive TCP stream exists.
+    pub fn nudge_passive_tcp_nomination(&self) {
+        if *self.inner.role.lock() != IceRole::Controlled {
+            return;
+        }
+        if self.inner.nomination_complete.borrow().is_some() {
+            return;
+        }
+        let inner = self.inner.clone();
+        info!("ICE: nudging passive TCP nomination (controlled, awaiting inbound TCP)");
+        tokio::spawn(async move {
+            let streams: Vec<_> = inner.gatherer.tcp_streams.lock().values().cloned().collect();
+            for wrapper in streams {
+                if let IceSocketWrapper::TcpStream(_, _, peer) = wrapper {
+                    complete_controlled_inbound_tcp_nomination(&wrapper, peer, inner).await;
+                    return;
+                }
+            }
+        });
+    }
+
     pub fn gather_state(&self) -> IceGathererState {
         self.inner.gatherer.state()
     }
@@ -1285,20 +1319,11 @@ impl IceTransport {
     }
 
     pub async fn get_selected_socket(&self) -> Option<IceSocketWrapper> {
-        let pair = self.inner.selected_pair.lock().clone()?;
-        if pair.local.typ == IceCandidateType::Relay {
-            let clients = self.inner.gatherer.turn_clients.lock();
-            clients
-                .get(&pair.local.address)
-                .map(|c| IceSocketWrapper::Turn(c.clone(), pair.local.address))
-        } else if pair.local.transport == "tcp" {
-            self.inner.gatherer.get_tcp_socket(pair.local.base_address())
-        } else {
-            self.inner
-                .gatherer
-                .get_socket(pair.local.base_address())
-                .map(IceSocketWrapper::Udp)
+        if let Some(socket) = self.inner._socket_rx_keeper.borrow().clone() {
+            return Some(socket);
         }
+        let pair = self.inner.selected_pair.lock().clone()?;
+        resolve_socket(&self.inner, &pair)
     }
 
     pub async fn get_selected_pair(&self) -> Option<IceCandidatePair> {
@@ -1397,11 +1422,32 @@ async fn perform_connectivity_checks_async(inner: Arc<IceTransportInner>) {
         return;
     }
 
-    let locals = inner.gatherer.local_candidates();
     let remotes = inner.remote_candidates.lock().clone();
     let role = *inner.role.lock();
 
-    if locals.is_empty() || remotes.is_empty() {
+    if remotes.is_empty() {
+        return;
+    }
+
+    let mut locals = inner.gatherer.local_candidates();
+
+    // Controlling agents may have no gathered locals when UDP is disabled and no TCP
+    // passive port range is configured. Synthesize active TCP locals so we open
+    // outbound connections to remote passive TCP candidates (RFC 6544).
+    if locals.is_empty() && role == IceRole::Controlling {
+        use std::net::{IpAddr, Ipv4Addr};
+        for remote in &remotes {
+            if remote.transport == "tcp" && remote.tcp_type == Some(TcpType::Passive) {
+                locals.push(IceCandidate::tcp(
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+                    remote.component,
+                    "active",
+                ));
+            }
+        }
+    }
+
+    if locals.is_empty() {
         return;
     }
 
@@ -1511,62 +1557,23 @@ async fn perform_connectivity_checks_async(inner: Arc<IceTransportInner>) {
 
     use futures::stream::StreamExt;
     let mut successful_pairs: Vec<IceCandidatePair> = Vec::new();
-    let mut nominated = false;
 
     while let Some(res) = checks.next().await {
-        if nominated {
-            continue;
-        }
-
-        // Guard: another concurrent task may have already nominated
-        if *inner.nomination_complete.borrow() == Some(true) {
-            nominated = true;
-            continue;
-        }
-
         if let Some(pair) = res {
+            // Skip duplicates (same local+remote already collected)
             let key = (pair.local.address, pair.remote.address);
             if successful_pairs.iter().any(|p| (p.local.address, p.remote.address) == key) {
                 continue;
             }
-
-            // Early nomination: try as soon as any pair check succeeds.
-            // On the same LAN, host:host completes in <1ms, but the old code
-            // waited for ALL checks (including slow relay/srflx timeouts)
-            // before starting nomination, causing ~5s delays.
-            if role == IceRole::Controlling {
-                *inner.selected_pair.lock() = Some(pair.clone());
-                let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
-                if let Some(socket) = resolve_socket(&inner, &pair) {
-                    let _ = inner.selected_socket.send(Some(socket.clone()));
-                    publish_selected_rtcp_socket(&inner, Some(socket));
-                }
-                let _ = inner.state.send(IceTransportState::Connected);
-
-                match perform_binding_check(&pair.local, &pair.remote, &inner, role, true).await {
-                    Ok(_) => {
-                        nominated = true;
-                        let _ = inner.nomination_complete.send(Some(true));
-                    }
-                    Err(_e) => {
-                        successful_pairs.push(pair);
-                    }
-                }
-            } else {
-                successful_pairs.push(pair);
-            }
+            successful_pairs.push(pair);
         }
     }
 
     if successful_pairs.is_empty() {
-        // All checks failed.  If we were NOT nominated externally (e.g. USE-CANDIDATE
-        // on the controlled side), transition to Failed.
-        if !nominated {
-            let state = *inner.state.borrow();
-            let has_selected_pair = inner.selected_pair.lock().is_some();
-            if state != IceTransportState::Connected && !has_selected_pair {
-                let _ = inner.state.send(IceTransportState::Failed);
-            }
+        let state = *inner.state.borrow();
+        let has_selected_pair = inner.selected_pair.lock().is_some();
+        if state != IceTransportState::Connected && !has_selected_pair {
+            let _ = inner.state.send(IceTransportState::Failed);
         }
         return;
     }
@@ -1575,32 +1582,54 @@ async fn perform_connectivity_checks_async(inner: Arc<IceTransportInner>) {
     successful_pairs.sort_by(|a, b| b.priority(role).cmp(&a.priority(role)));
 
     if role == IceRole::Controlling {
-        if !nominated {
-            // Try nomination on each successful pair in priority order.
-            // First successful nomination wins; fall through to next pair on failure.
-            for pair in &successful_pairs {
-                *inner.selected_pair.lock() = Some(pair.clone());
-                let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
-                if let Some(socket) = resolve_socket(&inner, pair) {
-                    let _ = inner.selected_socket.send(Some(socket.clone()));
-                    publish_selected_rtcp_socket(&inner, Some(socket));
-                }
-                let _ = inner.state.send(IceTransportState::Connected);
+        // Try nomination on each successful pair in priority order.
+        // First successful nomination wins; fall through to next pair on failure.
+        let mut nominated = false;
+        for pair in &successful_pairs {
+            *inner.selected_pair.lock() = Some(pair.clone());
+            let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
+            if let Some(socket) = resolve_socket(&inner, pair) {
+                let _ = inner.selected_socket.send(Some(socket.clone()));
+                publish_selected_rtcp_socket(&inner, Some(socket));
+            }
+            let _ = inner.state.send(IceTransportState::Connected);
+            debug!(
+                "ICE checks complete. Selected pair: {} -> {}",
+                pair.local.address, pair.remote.address
+            );
+            debug!(
+                "Controlling agent nominating pair: {} -> {}",
+                pair.local.address, pair.remote.address
+            );
 
-                match perform_binding_check(&pair.local, &pair.remote, &inner, role, true).await
-                {
-                    Ok(_) => {
-                        nominated = true;
-                        let _ = inner.nomination_complete.send(Some(true));
-                        break;
-                    }
-                    Err(_e) => {}
+            let result =
+                perform_binding_check(&pair.local, &pair.remote, &inner, role, true).await;
+            match &result {
+                Ok(_) => {
+                    debug!(
+                        "Nomination succeeded: {} -> {}",
+                        pair.local.address, pair.remote.address
+                    );
+                    let _ = inner.nomination_complete.send(Some(true));
+                    nominated = true;
+                    break;
+                }
+                Err(e) => {
+                    debug!(
+                        "Failed to send nomination for {} -> {}: {}",
+                        pair.local.address, pair.remote.address, e
+                    );
+                    // Fall through to next pair
                 }
             }
-            if !nominated {
-                let _ = inner.nomination_complete.send(Some(false));
-                let _ = inner.state.send(IceTransportState::Failed);
-            }
+        }
+        if !nominated {
+            debug!(
+                "All nomination attempts failed ({} pairs tried)",
+                successful_pairs.len()
+            );
+            let _ = inner.nomination_complete.send(Some(false));
+            let _ = inner.state.send(IceTransportState::Failed);
         }
     } else {
         // Controlled side: select best pair but don't nominate.
@@ -1614,6 +1643,13 @@ async fn perform_connectivity_checks_async(inner: Arc<IceTransportInner>) {
             publish_selected_rtcp_socket(&inner, Some(socket));
         }
         let _ = inner.state.send(IceTransportState::Connected);
+        if pair.local.transport == "tcp" {
+            let _ = inner.nomination_complete.send(Some(true));
+        }
+        debug!(
+            "ICE checks complete. Selected pair: {} -> {}",
+            pair.local.address, pair.remote.address
+        );
     }
 }
 
@@ -1624,19 +1660,19 @@ fn resolve_socket(inner: &IceTransportInner, pair: &IceCandidatePair) -> Option<
             .get(&pair.local.address)
             .map(|c| IceSocketWrapper::Turn(c.clone(), pair.local.address))
     } else if pair.local.transport == "tcp" {
-        // Try lookup by local address first, then fall back to peer match
-        if let Some(socket) = inner.gatherer.get_tcp_socket(pair.local.base_address()) {
-            return Some(socket);
-        }
+        // Prefer the accepted inbound stream that matches the nominated remote peer.
+        // get_tcp_socket() keys by listener local_addr and may return a stale socket
+        // when multiple sessions share a passive port range.
         let streams = inner.gatherer.tcp_streams.lock();
         for wrapper in streams.values() {
-            if let IceSocketWrapper::TcpStream(_, peer) = wrapper {
+            if let IceSocketWrapper::TcpStream(_, _, peer) = wrapper {
                 if *peer == pair.remote.address {
                     return Some(wrapper.clone());
                 }
             }
         }
-        None
+        drop(streams);
+        inner.gatherer.get_tcp_socket(pair.local.base_address())
     } else {
         let socket = inner.gatherer.get_socket(pair.local.base_address());
         if socket.is_none() {
@@ -1647,6 +1683,124 @@ fn resolve_socket(inner: &IceTransportInner, pair: &IceCandidatePair) -> Option<
         }
         socket.map(IceSocketWrapper::Udp)
     }
+}
+
+fn publish_selected_socket(
+    inner: &IceTransportInner,
+    pair: &IceCandidatePair,
+    inbound: Option<&IceSocketWrapper>,
+) {
+    // Inbound TCP is authoritative for passive ICE-TCP: the controlling peer
+    // connected to us on this stream and nominated it via USE-CANDIDATE.
+    let socket = match inbound {
+        Some(s @ IceSocketWrapper::TcpStream(_, _, _)) => Some(s.clone()),
+        _ => resolve_socket(inner, pair),
+    };
+    if let Some(socket) = socket {
+        info!(
+            pair_local = %pair.local.address,
+            pair_remote = %pair.remote.address,
+            socket = %socket.diag(),
+            inbound_tcp = matches!(inbound, Some(IceSocketWrapper::TcpStream(_, _, _))),
+            "ICE: published selected socket"
+        );
+        let _ = inner.selected_socket.send(Some(socket.clone()));
+        publish_selected_rtcp_socket(inner, Some(socket));
+    }
+}
+
+async fn complete_controlled_inbound_tcp_nomination(
+    sender: &IceSocketWrapper,
+    addr: SocketAddr,
+    inner: Arc<IceTransportInner>,
+) {
+    if *inner.role.lock() != IceRole::Controlled {
+        return;
+    }
+    let IceSocketWrapper::TcpStream(read, _, _) = sender else {
+        return;
+    };
+    if inner.nomination_complete.borrow().is_some() {
+        if let Some(pair) = inner.selected_pair.lock().clone() {
+            publish_selected_socket(&inner, &pair, Some(sender));
+        }
+        return;
+    }
+
+    let local_addr: SocketAddr = {
+        let s = read.lock().await;
+        s.local_addr()
+            .unwrap_or_else(|_| "0.0.0.0:0".parse().unwrap())
+    };
+
+    let locals = inner.gatherer.local_candidates();
+    let local_cand = locals.iter().find(|c| {
+        c.base_address() == local_addr
+            || (c.transport == "tcp"
+                && c.base_address().port() == local_addr.port()
+                && (c.base_address().ip().is_unspecified()
+                    || local_addr.ip().is_unspecified()))
+    });
+
+    let pair = {
+        let remotes = inner.remote_candidates.lock();
+        let remote_cand = remotes.iter().find(|c| c.address == addr);
+        if let (Some(l), Some(r)) = (local_cand, remote_cand) {
+            Some(IceCandidatePair::new(l.clone(), r.clone()))
+        } else {
+            None
+        }
+    };
+
+    if let Some(pair) = pair {
+        trace!(
+            "Controlled agent selected pair via inbound TCP nomination: {} -> {}",
+            pair.local.address, pair.remote.address
+        );
+        *inner.selected_pair.lock() = Some(pair.clone());
+        let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
+        publish_selected_socket(&inner, &pair, Some(sender));
+        let _ = inner.state.send(IceTransportState::Connected);
+    } else {
+        debug!(
+            "Inbound TCP nomination: synthesizing pair for {} -> {}",
+            local_addr, addr
+        );
+        let local_cand = locals.iter().find(|c| {
+            c.transport == "tcp"
+                && c.tcp_type == Some(TcpType::Passive)
+                && (c.base_address().port() == local_addr.port()
+                    || c.address.port() == local_addr.port())
+        });
+        let remote_cand = {
+            let remotes = inner.remote_candidates.lock();
+            remotes.iter().find(|c| c.address == addr).cloned()
+        };
+        if let (Some(l), Some(r)) = (local_cand, remote_cand) {
+            let pair = IceCandidatePair::new(l.clone(), r.clone());
+            *inner.selected_pair.lock() = Some(pair.clone());
+            let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
+            publish_selected_socket(&inner, &pair, Some(sender));
+            let _ = inner.state.send(IceTransportState::Connected);
+        } else {
+            let _ = inner.selected_socket.send(Some(sender.clone()));
+            publish_selected_rtcp_socket(&inner, Some(sender.clone()));
+        }
+    }
+    let _ = inner.nomination_complete.send(Some(true));
+    let pair_summary = inner
+        .selected_pair
+        .lock()
+        .as_ref()
+        .map(|p| format!("{} -> {}", p.local.address, p.remote.address))
+        .unwrap_or_else(|| format!("(no pair) peer={addr}"));
+    info!(
+        peer = %addr,
+        local_bind = %local_addr,
+        pair = %pair_summary,
+        socket = %sender.diag(),
+        "ICE: passive TCP nomination complete"
+    );
 }
 
 fn resolve_rtcp_socket(inner: &IceTransportInner) -> Option<IceSocketWrapper> {
@@ -1897,7 +2051,7 @@ async fn handle_stun_request(
         debug!("Discovered peer reflexive candidate: {}", addr);
         let transport = match sender {
             IceSocketWrapper::Udp(_) => "udp",
-            IceSocketWrapper::TcpListener(_) | IceSocketWrapper::TcpStream(_, _) => "tcp",
+            IceSocketWrapper::TcpListener(_) | IceSocketWrapper::TcpStream(_, _, _) => "tcp",
             IceSocketWrapper::Turn(_, _) => "udp",
         };
         let mut candidate = IceCandidate::host(addr, 1); // Use host for now, or prflx
@@ -1933,24 +2087,24 @@ async fn handle_stun_request(
                 let new_pair = IceCandidatePair::new(pair.local.clone(), new_remote);
                 *inner.selected_pair.lock() = Some(new_pair.clone());
                 let _ = inner.selected_pair_notifier.send(Some(new_pair.clone()));
-                if let Some(socket) = resolve_socket(&inner, &new_pair) {
-                    let _ = inner.selected_socket.send(Some(socket.clone()));
-                    publish_selected_rtcp_socket(&inner, Some(socket));
-                }
+                publish_selected_socket(&inner, &new_pair, Some(sender));
             }
         }
     }
 
+    complete_controlled_inbound_tcp_nomination(sender, addr, inner.clone()).await;
+
     if msg.use_candidate {
         let role = *inner.role.lock();
         if role == IceRole::Controlled {
+            // TCP passive nomination is handled above; UDP still uses USE-CANDIDATE below.
+            if matches!(sender, IceSocketWrapper::TcpStream(_, _, _)) {
+                return;
+            }
             // RFC 8445 §7.3.1.5: once a pair is already nominated, subsequent
             // USE-CANDIDATE (e.g. keepalives from other candidates) must not
             // trigger re-nomination.  Guard here to prevent pair_monitor churn.
             if inner.selected_pair.lock().is_some() {
-                // Pair was selected via connectivity checks before USE-CANDIDATE arrived.
-                // Still need to signal nomination_complete if not done yet — otherwise
-                // peer_connection waits the full nomination_timeout (10 s) before DTLS.
                 if inner.nomination_complete.borrow().is_none() {
                     trace!(
                         "Controlled agent: pair already selected, signalling nomination_complete via UseCandidate from {}",
@@ -1971,8 +2125,8 @@ async fn handle_stun_request(
                     IceSocketWrapper::TcpListener(l) => l
                         .local_addr()
                         .unwrap_or_else(|_| "0.0.0.0:0".parse().unwrap()),
-                    IceSocketWrapper::TcpStream(stream, _) => {
-                        let s = stream.lock().await;
+                    IceSocketWrapper::TcpStream(read, _, _) => {
+                        let s = read.lock().await;
                         s.local_addr()
                             .unwrap_or_else(|_| "0.0.0.0:0".parse().unwrap())
                     }
@@ -1999,23 +2153,14 @@ async fn handle_stun_request(
                     );
                     *inner.selected_pair.lock() = Some(pair.clone());
                     let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
-                    if let Some(socket) = resolve_socket(&inner, &pair) {
-                        let _ = inner.selected_socket.send(Some(socket.clone()));
-                        publish_selected_rtcp_socket(&inner, Some(socket));
-                    }
+                    publish_selected_socket(&inner, &pair, Some(sender));
                     let _ = inner.state.send(IceTransportState::Connected);
-                    // Controlled side: nomination is decided by the controlling agent;
-                    // once we receive USE-CANDIDATE, our "nomination" is complete.
                     let _ = inner.nomination_complete.send(Some(true));
                 } else {
                     debug!(
-                        "Received UseCandidate but could not find pair for {} -> {}; \
-                         signalling nomination_complete=Some(true) as fallback",
+                        "Received UseCandidate but could not find UDP pair for {} -> {}",
                         local_addr, addr
                     );
-                    // Fallback: USE-CANDIDATE arrived before ICE checks completed
-                    // (pair not yet in remote_candidates).  Signal nomination complete
-                    // so peer_connection is not stuck waiting forever.
                     let _ = inner.nomination_complete.send(Some(true));
                 }
             }
@@ -2309,6 +2454,49 @@ async fn perform_binding_check(
 /// 2. Send the STUN binding request over the TCP stream
 /// 3. Read the response, decode it, and deliver it to the pending transaction
 /// 4. Store the stream for later media use
+/// RFC 4571 STUN/TCP framing used by WebRTC (length prefix + message).
+fn frame_stun_for_tcp(data: &[u8]) -> Vec<u8> {
+    let len = data.len() as u16;
+    let mut framed = Vec::with_capacity(2 + data.len());
+    framed.extend_from_slice(&len.to_be_bytes());
+    framed.extend_from_slice(data);
+    framed
+}
+
+type TcpReadHalf = tokio::net::tcp::OwnedReadHalf;
+type TcpWriteHalf = tokio::net::tcp::OwnedWriteHalf;
+
+fn split_tcp_stream(stream: TcpStream, peer: SocketAddr) -> IceSocketWrapper {
+    if let Err(e) = stream.set_nodelay(true) {
+        debug!("TCP set_nodelay failed: {}", e);
+    }
+    let (read, write) = stream.into_split();
+    IceSocketWrapper::TcpStream(
+        Arc::new(Mutex::new(read)),
+        Arc::new(Mutex::new(write)),
+        peer,
+    )
+}
+
+pub(crate) async fn tcp_write_all(write: &Arc<Mutex<TcpWriteHalf>>, data: &[u8]) -> Result<()> {
+    let mut offset = 0;
+    while offset < data.len() {
+        let mut guard = write.lock().await;
+        loop {
+            match guard.try_write(&data[offset..]) {
+                Ok(0) => guard.writable().await?,
+                Ok(n) => {
+                    offset += n;
+                    break;
+                }
+                Err(e) if e.kind() == ErrorKind::WouldBlock => guard.writable().await?,
+                Err(e) => return Err(anyhow!("TCP write failed: {}", e)),
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn perform_tcp_binding_check(
     local: &IceCandidate,
     remote: &IceCandidate,
@@ -2352,15 +2540,14 @@ async fn perform_tcp_binding_check(
         .map_err(|_| anyhow!("TCP connect timeout to {}", remote.address))?
         .map_err(|e| anyhow!("TCP connect to {} failed: {}", remote.address, e))?;
 
-    if let Err(e) = stream.set_nodelay(true) {
-        debug!("TCP set_nodelay failed: {}", e);
-    }
-
     let local_addr = stream.local_addr()?;
-    let stream = Arc::new(Mutex::new(stream));
+    let wrapper = split_tcp_stream(stream, remote.address);
+    let write = match &wrapper {
+        IceSocketWrapper::TcpStream(_, write, _) => write.clone(),
+        _ => bail!("split_tcp_stream invariant"),
+    };
 
     // Register the TCP stream with the runner so its read loop handles incoming STUN responses
-    let wrapper = IceSocketWrapper::TcpStream(stream.clone(), remote.address);
     inner.gatherer.store_tcp_stream(local_addr, wrapper.clone());
     let _ = inner.gatherer.socket_tx.send(wrapper);
 
@@ -2375,13 +2562,13 @@ async fn perform_tcp_binding_check(
         tx_id,
     };
 
-    // Send STUN binding request over TCP
+    // Send STUN binding request over TCP (RFC 4571 framed)
     {
-        let mut s = stream.lock().await;
-        s.write_all(&bytes).await?;
+        let framed = frame_stun_for_tcp(&bytes);
+        tcp_write_all(&write, &framed).await?;
     }
 
-    // Wait for response (with retransmissions)
+    // Wait for response (with retransmissions) via read loop → pending_transactions
     let start = Instant::now();
     let mut rto = Duration::from_millis(500);
     let max_timeout = if nominated {
@@ -2420,9 +2607,8 @@ async fn perform_tcp_binding_check(
                 }
                 trace!("TCP Retransmitting STUN Request to {} tx={:?}", remote.address, tx_id);
                 rto = std::cmp::min(rto * 2, Duration::from_millis(1600));
-                // Retransmit over TCP
-                let mut s = stream.lock().await;
-                let _ = s.write_all(&bytes).await;
+                let framed = frame_stun_for_tcp(&bytes);
+                let _ = tcp_write_all(&write, &framed).await;
             }
         }
     }
@@ -2985,6 +3171,11 @@ impl IceGatherer {
                     if let Err(e) = self.gather_host_candidates().await {
                         debug!("Host gathering failed: {}", e);
                     }
+                } else if self.config.ice_tcp_policy == crate::config::IceTcpPolicy::Enabled {
+                    // Controlling ICE-TCP clients (no UDP): advertise active TCP locals.
+                    if let Err(e) = self.gather_tcp_active_candidates().await {
+                        debug!("TCP active gathering failed: {}", e);
+                    }
                 }
             }
         };
@@ -3121,14 +3312,7 @@ impl IceGatherer {
                                 .socket_tx
                                 .send(IceSocketWrapper::TcpListener(listener));
 
-                            let tcp_type = if self.config.ice_tcp_policy
-                                == crate::config::IceTcpPolicy::PassiveOnly
-                            {
-                                TcpType::Passive
-                            } else {
-                                TcpType::Passive
-                            };
-
+                            let tcp_type = TcpType::Passive;
                             let mut cand = IceCandidate::host_tcp(addr, 1, tcp_type);
                             if ip.is_unspecified() {
                                 if let Ok(local_ip) = get_local_ip() {
@@ -3149,6 +3333,28 @@ impl IceGatherer {
             }
         }
 
+        Ok(())
+    }
+
+    /// Advertise ICE-TCP active host candidates for controlling clients (no UDP gather).
+    async fn gather_tcp_active_candidates(&self) -> Result<()> {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let mut bind_ips = vec![IpAddr::V4(Ipv4Addr::LOCALHOST)];
+        if let Ok(local_ip) = get_local_ip() {
+            if !bind_ips.contains(&local_ip) {
+                bind_ips.push(local_ip);
+            }
+        }
+
+        for ip in bind_ips {
+            self.push_candidate(IceCandidate::tcp(SocketAddr::new(ip, 0), 1, "active"));
+        }
+        self.push_candidate(IceCandidate::tcp(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+            1,
+            "active",
+        ));
         Ok(())
     }
 
@@ -3190,6 +3396,8 @@ impl IceGatherer {
             ips
         };
 
+        // One passive TCP listener per local IP (first free port in range). Binding the
+        // entire range per PeerConnection exhausts the pool after a single session.
         for ip in bind_ips {
             for port in start..=end {
                 let addr = SocketAddr::new(ip, port);
@@ -3200,7 +3408,8 @@ impl IceGatherer {
                             Err(_) => continue,
                         };
                         let listener = Arc::new(listener);
-                        let _ = self.socket_tx.send(IceSocketWrapper::TcpListener(listener.clone()));
+                        self.tcp_listeners.lock().push(listener.clone());
+                        let _ = self.socket_tx.send(IceSocketWrapper::TcpListener(listener));
 
                         if let Some(ext_ip) = &self.config.external_ip
                             && let Ok(parsed_ip) = ext_ip.parse::<IpAddr>()
@@ -3225,6 +3434,7 @@ impl IceGatherer {
                         } else {
                             self.push_candidate(IceCandidate::tcp(local_addr, 1, "passive"));
                         }
+                        break;
                     }
                     Err(_) => continue,
                 }
@@ -3668,11 +3878,31 @@ fn hex_encode(bytes: &[u8]) -> String {
 pub enum IceSocketWrapper {
     Udp(Arc<UdpSocket>),
     TcpListener(Arc<TcpListener>),
-    TcpStream(Arc<Mutex<TcpStream>>, SocketAddr),
+    TcpStream(Arc<Mutex<TcpReadHalf>>, Arc<Mutex<TcpWriteHalf>>, SocketAddr),
     Turn(Arc<TurnClient>, SocketAddr),
 }
 
 impl IceSocketWrapper {
+    /// Short description for diagnostic logs (no async I/O).
+    pub fn diag(&self) -> String {
+        match self {
+            IceSocketWrapper::Udp(s) => format!(
+                "udp:{}",
+                s.local_addr()
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|_| "?".into())
+            ),
+            IceSocketWrapper::TcpListener(l) => format!(
+                "tcp-listen:{}",
+                l.local_addr()
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|_| "?".into())
+            ),
+            IceSocketWrapper::TcpStream(_, _, peer) => format!("tcp-stream:peer={peer}"),
+            IceSocketWrapper::Turn(_, addr) => format!("turn:{addr}"),
+        }
+    }
+
     pub async fn send_to(&self, data: &[u8], addr: SocketAddr) -> Result<usize> {
         match self {
             IceSocketWrapper::Udp(s) => loop {
@@ -3697,8 +3927,7 @@ impl IceSocketWrapper {
             IceSocketWrapper::TcpListener(_) => {
                 bail!("send_to not supported on TcpListener")
             }
-            IceSocketWrapper::TcpStream(s, _) => {
-                let stream = s.lock().await;
+            IceSocketWrapper::TcpStream(_, write, _) => {
                 let len = data.len();
                 if len > 0xFFFF {
                     bail!("STUN message too large for TCP framing");
@@ -3707,24 +3936,8 @@ impl IceSocketWrapper {
                 let mut framed = Vec::with_capacity(2 + len);
                 framed.extend_from_slice(&header);
                 framed.extend_from_slice(data);
-                loop {
-                    match (&*stream).try_write(&framed) {
-                        Ok(n) => {
-                            if n < framed.len() {
-                                framed = framed.split_off(n);
-                                continue;
-                            }
-                            return Ok(data.len());
-                        }
-                        Err(e) if e.kind() == ErrorKind::WouldBlock => {
-                            stream.writable().await?;
-                            continue;
-                        }
-                        Err(e) => {
-                            return Err(anyhow!("TCP send failed: {}", e));
-                        }
-                    }
-                }
+                tcp_write_all(write, &framed).await?;
+                Ok(data.len())
             }
             IceSocketWrapper::Turn(c, _) => {
                 if let Some(channel) = c.get_channel(addr).await {
@@ -3740,9 +3953,9 @@ impl IceSocketWrapper {
     pub async fn recv_from(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
         match self {
             IceSocketWrapper::Udp(s) => s.recv_from(buf).await.map_err(|e| e.into()),
-            IceSocketWrapper::TcpStream(s, peer) => {
+            IceSocketWrapper::TcpStream(read, _, peer) => {
                 use tokio::io::AsyncReadExt;
-                let mut stream = s.lock().await;
+                let mut stream = read.lock().await;
                 let mut len_buf = [0u8; 2];
                 stream.read_exact(&mut len_buf).await?;
                 let len = u16::from_be_bytes(len_buf) as usize;

--- a/src/transports/ice/mod.rs
+++ b/src/transports/ice/mod.rs
@@ -3172,9 +3172,20 @@ impl IceGatherer {
                         debug!("Host gathering failed: {}", e);
                     }
                 } else if self.config.ice_tcp_policy == crate::config::IceTcpPolicy::Enabled {
-                    // Controlling ICE-TCP clients (no UDP): advertise active TCP locals.
-                    if let Err(e) = self.gather_tcp_active_candidates().await {
-                        debug!("TCP active gathering failed: {}", e);
+                    // Outbound controlling peers with no TCP listen range advertise active locals.
+                    // WHEP/answerer setups configure tcp_port_range_* for passive listeners;
+                    // skip active placeholders so SDP does not contain invalid port 0 candidates.
+                    let has_tcp_listen_range = match (
+                        self.config.tcp_port_range_start,
+                        self.config.tcp_port_range_end,
+                    ) {
+                        (Some(s), Some(e)) => s > 0 && e > 0 && s <= e,
+                        _ => false,
+                    };
+                    if !has_tcp_listen_range {
+                        if let Err(e) = self.gather_tcp_active_candidates().await {
+                            debug!("TCP active gathering failed: {}", e);
+                        }
                     }
                 }
             }
@@ -3337,8 +3348,12 @@ impl IceGatherer {
     }
 
     /// Advertise ICE-TCP active host candidates for controlling clients (no UDP gather).
+    ///
+    /// RFC 6544 uses port 9 in SDP for active candidates (not 0 — browsers reject port 0).
     async fn gather_tcp_active_candidates(&self) -> Result<()> {
         use std::net::{IpAddr, Ipv4Addr};
+
+        const ACTIVE_PLACEHOLDER_PORT: u16 = 9;
 
         let mut bind_ips = vec![IpAddr::V4(Ipv4Addr::LOCALHOST)];
         if let Ok(local_ip) = get_local_ip() {
@@ -3348,10 +3363,14 @@ impl IceGatherer {
         }
 
         for ip in bind_ips {
-            self.push_candidate(IceCandidate::tcp(SocketAddr::new(ip, 0), 1, "active"));
+            self.push_candidate(IceCandidate::tcp(
+                SocketAddr::new(ip, ACTIVE_PLACEHOLDER_PORT),
+                1,
+                "active",
+            ));
         }
         self.push_candidate(IceCandidate::tcp(
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), ACTIVE_PLACEHOLDER_PORT),
             1,
             "active",
         ));

--- a/src/transports/rtp.rs
+++ b/src/transports/rtp.rs
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Weak};
 use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
 
 const EXT_ID_NONE: u8 = 0;
 
@@ -395,16 +396,19 @@ impl RtpTransport {
     }
 
     pub async fn send_rtp(&self, mut packet: RtpPacket) -> Result<usize> {
-        if !self.has_sent_first_packet.load(Ordering::Relaxed) {
+        let is_first = !self.has_sent_first_packet.load(Ordering::Relaxed);
+        if is_first {
             self.has_sent_first_packet.store(true, Ordering::Relaxed);
             packet.header.marker = true;
         }
 
-        // Inject abs-send-time if enabled
+        // Inject abs-send-time if enabled (non-fatal: header may lack room on small payloads).
         if let Some(id) = decode_ext_id(self.abs_send_time_extension_id.load(Ordering::Relaxed)) {
             let abs_send_time = crate::rtp::calculate_abs_send_time(std::time::SystemTime::now());
             let data = abs_send_time.to_be_bytes()[1..4].to_vec();
-            packet.header.set_extension(id, &data)?;
+            if let Err(e) = packet.header.set_extension(id, &data) {
+                debug!("RtpTransport: abs-send-time extension skipped: {}", e);
+            }
         }
 
         let protected = {
@@ -415,12 +419,27 @@ impl RtpTransport {
                 packet.marshal()?
             } else {
                 if self.srtp_required {
+                    warn!("RtpTransport: SRTP required but session not ready, dropping RTP send");
                     return Err(anyhow::anyhow!("SRTP required but session not ready"));
                 }
                 packet.marshal()?
             }
         };
-        self.transport.send(&protected).await
+        match self.transport.send(&protected).await {
+            Ok(n) => {
+                if is_first {
+                    info!(
+                        "RtpTransport: first SRTP packet sent ({} bytes)",
+                        protected.len()
+                    );
+                }
+                Ok(n)
+            }
+            Err(e) => {
+                warn!("RtpTransport: failed to send SRTP packet ({} bytes): {}", protected.len(), e);
+                Err(e)
+            }
+        }
     }
 
     pub async fn send_rtcp(&self, packets: &[RtcpPacket]) -> Result<usize> {


### PR DESCRIPTION
- Split ICE TCP stream into read/write halves to avoid send blocking recv
- Batch DTLS records with RFC 4571 framing for TCP handshake
- Make abs-send-time RTP extension injection non-fatal
- Reuse offer transceiver on add_track for WHEP answerer MID binding
- Start DTLS runner before flushing buffered packets; nudge passive TCP nomination