### PR TITLE
feat(ice): shared passive TCP listener for single-port WHEP answerer

### DIFF
--- a/src/transports/ice/mod.rs
+++ b/src/transports/ice/mod.rs
@@ -1,4 +1,5 @@
 pub mod conn;
+pub mod shared_tcp;
 pub mod stun;
 #[cfg(test)]
 mod tests;
@@ -798,6 +799,7 @@ impl IceTransport {
             buffer_stats: Arc::new(BufferStats::default()),
         };
         let inner = Arc::new(inner);
+        inner.gatherer.set_transport(Arc::downgrade(&inner));
 
         let runner = IceTransportRunner {
             inner: inner.clone(),
@@ -1281,6 +1283,7 @@ impl IceTransport {
         self.inner.gatherer.sockets.lock().clear();
         self.inner.gatherer.tcp_listeners.lock().clear();
         self.inner.gatherer.tcp_streams.lock().clear();
+        self.inner.gatherer.shared_tcp_regs.lock().clear();
         self.inner.gatherer.turn_clients.lock().clear();
     }
 
@@ -2478,6 +2481,21 @@ fn split_tcp_stream(stream: TcpStream, peer: SocketAddr) -> IceSocketWrapper {
     )
 }
 
+pub(crate) async fn attach_demuxed_tcp_stream(
+    inner: Arc<IceTransportInner>,
+    stream: TcpStream,
+    peer_addr: SocketAddr,
+    listen_addr: SocketAddr,
+    first_packet: Vec<u8>,
+) {
+    let wrapper = split_tcp_stream(stream, peer_addr);
+    inner
+        .gatherer
+        .store_tcp_stream(listen_addr, wrapper.clone());
+    let _ = inner.gatherer.socket_tx.send(wrapper.clone());
+    handle_packet(&first_packet, peer_addr, inner, wrapper).await;
+}
+
 pub(crate) async fn tcp_write_all(write: &Arc<Mutex<TcpWriteHalf>>, data: &[u8]) -> Result<()> {
     let mut offset = 0;
     while offset < data.len() {
@@ -3018,6 +3036,8 @@ struct IceGatherer {
     sockets: Arc<parking_lot::Mutex<Vec<Arc<UdpSocket>>>>,
     tcp_listeners: Arc<parking_lot::Mutex<Vec<Arc<TcpListener>>>>,
     tcp_streams: Arc<parking_lot::Mutex<HashMap<SocketAddr, IceSocketWrapper>>>,
+    shared_tcp_regs: Arc<parking_lot::Mutex<Vec<shared_tcp::SharedTcpRegistration>>>,
+    transport_inner: Arc<parking_lot::Mutex<Option<std::sync::Weak<IceTransportInner>>>>,
     turn_clients: Arc<parking_lot::Mutex<HashMap<SocketAddr, Arc<TurnClient>>>>,
     upnp_mappers: Arc<parking_lot::Mutex<Vec<UpnpPortMapper>>>,
     config: RtcConfiguration,
@@ -3037,11 +3057,43 @@ impl IceGatherer {
             sockets: Arc::new(parking_lot::Mutex::new(Vec::new())),
             tcp_listeners: Arc::new(parking_lot::Mutex::new(Vec::new())),
             tcp_streams: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            shared_tcp_regs: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            transport_inner: Arc::new(parking_lot::Mutex::new(None)),
             turn_clients: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             upnp_mappers: Arc::new(parking_lot::Mutex::new(Vec::new())),
             config,
             candidate_tx,
             socket_tx,
+        }
+    }
+
+    fn set_transport(&self, inner: std::sync::Weak<IceTransportInner>) {
+        *self.transport_inner.lock() = Some(inner);
+    }
+
+    fn push_tcp_passive_candidate(&self, local_addr: SocketAddr, bind_ip: IpAddr) {
+        if let Some(ext_ip) = &self.config.external_ip
+            && let Ok(parsed_ip) = ext_ip.parse::<IpAddr>()
+        {
+            if !bind_ip.is_loopback() {
+                let mut ext_addr = local_addr;
+                ext_addr.set_ip(parsed_ip);
+                let mut cand = IceCandidate::tcp(ext_addr, 1, "passive");
+                cand.related_address = Some(local_addr);
+                self.push_candidate(cand);
+            } else {
+                self.push_candidate(IceCandidate::tcp(local_addr, 1, "passive"));
+            }
+        } else if bind_ip.is_unspecified() {
+            let mut cand_addr = local_addr;
+            if let Ok(local_ip) = get_local_ip() {
+                cand_addr.set_ip(local_ip);
+            }
+            let mut cand = IceCandidate::tcp(cand_addr, 1, "passive");
+            cand.related_address = Some(local_addr);
+            self.push_candidate(cand);
+        } else {
+            self.push_candidate(IceCandidate::tcp(local_addr, 1, "passive"));
         }
     }
 
@@ -3417,7 +3469,32 @@ impl IceGatherer {
 
         // One passive TCP listener per local IP (first free port in range). Binding the
         // entire range per PeerConnection exhausts the pool after a single session.
+        // When start == end, share one listener process-wide and demux by ICE ufrag.
+        let use_shared_listener = start == end;
+
         for ip in bind_ips {
+            if use_shared_listener {
+                let addr = SocketAddr::new(ip, start);
+                let inner = self
+                    .transport_inner
+                    .lock()
+                    .as_ref()
+                    .and_then(|weak| weak.upgrade())
+                    .context("ICE transport unavailable during TCP gather")?;
+                let ufrag = inner.local_parameters.lock().username_fragment.clone();
+                match shared_tcp::acquire(addr, ufrag, Arc::downgrade(&inner)).await {
+                    Ok((local_addr, registration)) => {
+                        self.shared_tcp_regs.lock().push(registration);
+                        self.push_tcp_passive_candidate(local_addr, ip);
+                        break;
+                    }
+                    Err(e) => {
+                        debug!("shared TCP listener acquire on {} failed: {}", addr, e);
+                    }
+                }
+                continue;
+            }
+
             for port in start..=end {
                 let addr = SocketAddr::new(ip, port);
                 match TcpListener::bind(addr).await {
@@ -3430,29 +3507,7 @@ impl IceGatherer {
                         self.tcp_listeners.lock().push(listener.clone());
                         let _ = self.socket_tx.send(IceSocketWrapper::TcpListener(listener));
 
-                        if let Some(ext_ip) = &self.config.external_ip
-                            && let Ok(parsed_ip) = ext_ip.parse::<IpAddr>()
-                        {
-                            if !ip.is_loopback() {
-                                let mut ext_addr = local_addr;
-                                ext_addr.set_ip(parsed_ip);
-                                let mut cand = IceCandidate::tcp(ext_addr, 1, "passive");
-                                cand.related_address = Some(local_addr);
-                                self.push_candidate(cand);
-                            } else {
-                                self.push_candidate(IceCandidate::tcp(local_addr, 1, "passive"));
-                            }
-                        } else if ip.is_unspecified() {
-                            let mut cand_addr = local_addr;
-                            if let Ok(local_ip) = get_local_ip() {
-                                cand_addr.set_ip(local_ip);
-                            }
-                            let mut cand = IceCandidate::tcp(cand_addr, 1, "passive");
-                            cand.related_address = Some(local_addr);
-                            self.push_candidate(cand);
-                        } else {
-                            self.push_candidate(IceCandidate::tcp(local_addr, 1, "passive"));
-                        }
+                        self.push_tcp_passive_candidate(local_addr, ip);
                         break;
                     }
                     Err(_) => continue,

--- a/src/transports/ice/shared_tcp.rs
+++ b/src/transports/ice/shared_tcp.rs
@@ -1,0 +1,240 @@
+//! Process-wide shared passive TCP listeners for single-port WHEP answerer mode.
+//!
+//! When `tcp_port_range_start == tcp_port_range_end`, multiple PeerConnections can
+//! register on the same listen socket. Incoming connections are demuxed by the
+//! server ufrag in the first STUN Binding request USERNAME attribute.
+
+use super::{IceTransportInner, MAX_STUN_MESSAGE, attach_demuxed_tcp_stream};
+use crate::transports::ice::stun::{StunAttribute, StunClass, StunMessage, StunMethod};
+use anyhow::{Context, Result, anyhow, bail};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock, Weak};
+use tokio::io::AsyncReadExt;
+use tokio::net::{TcpListener, TcpStream};
+use tracing::debug;
+
+static SHARED_PORTS: OnceLock<Mutex<HashMap<SocketAddr, Arc<SharedTcpPort>>>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<HashMap<SocketAddr, Arc<SharedTcpPort>>> {
+    SHARED_PORTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+struct SharedTcpPort {
+    listener: Arc<TcpListener>,
+    sessions: Mutex<HashMap<String, Weak<IceTransportInner>>>,
+    ref_count: AtomicUsize,
+    shutting_down: AtomicBool,
+}
+
+impl SharedTcpPort {
+    fn new(listener: Arc<TcpListener>) -> Self {
+        Self {
+            listener,
+            sessions: Mutex::new(HashMap::new()),
+            ref_count: AtomicUsize::new(0),
+            shutting_down: AtomicBool::new(false),
+        }
+    }
+
+    fn spawn_accept_loop(self: &Arc<Self>) {
+        let port = Arc::clone(self);
+        let listener = Arc::clone(&self.listener);
+        tokio::spawn(async move {
+            loop {
+                if port.shutting_down.load(Ordering::Relaxed) {
+                    break;
+                }
+                let accept = listener.accept().await;
+                match accept {
+                    Ok((stream, peer)) => {
+                        let port = Arc::clone(&port);
+                        tokio::spawn(async move {
+                            if let Err(e) = dispatch_incoming(stream, peer, port).await {
+                                debug!("shared TCP demux failed from {}: {}", peer, e);
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        if port.shutting_down.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        debug!("shared TCP accept error: {}", e);
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    }
+                }
+            }
+        });
+    }
+}
+
+/// Keeps a PeerConnection registered on a shared passive TCP port until dropped.
+pub(crate) struct SharedTcpRegistration {
+    port: Arc<SharedTcpPort>,
+    listen_key: SocketAddr,
+    ufrag: String,
+}
+
+impl std::fmt::Debug for SharedTcpRegistration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedTcpRegistration")
+            .field("listen_key", &self.listen_key)
+            .field("ufrag", &self.ufrag)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for SharedTcpRegistration {
+    fn drop(&mut self) {
+        self.port.sessions.lock().remove(&self.ufrag);
+        let prev = self.port.ref_count.fetch_sub(1, Ordering::SeqCst);
+        if prev == 1 {
+            self.port.shutting_down.store(true, Ordering::SeqCst);
+            registry().lock().remove(&self.listen_key);
+        }
+    }
+}
+
+/// Bind or join the shared listener at `bind_addr` and register `local_ufrag`.
+pub(crate) async fn acquire(
+    bind_addr: SocketAddr,
+    local_ufrag: String,
+    inner: Weak<IceTransportInner>,
+) -> Result<(SocketAddr, SharedTcpRegistration)> {
+    let maybe_existing = registry().lock().get(&bind_addr).cloned();
+    let port = if let Some(existing) = maybe_existing {
+        existing
+    } else {
+        let listener = TcpListener::bind(bind_addr)
+            .await
+            .with_context(|| format!("bind shared TCP listener {bind_addr}"))?;
+        let listener = Arc::new(listener);
+        let port = Arc::new(SharedTcpPort::new(listener));
+
+        let mut reg = registry().lock();
+        if let Some(existing) = reg.get(&bind_addr) {
+            existing.clone()
+        } else {
+            reg.insert(bind_addr, port.clone());
+            port.spawn_accept_loop();
+            port
+        }
+    };
+
+    port.ref_count.fetch_add(1, Ordering::SeqCst);
+    port.sessions.lock().insert(local_ufrag.clone(), inner);
+
+    let local_addr = port
+        .listener
+        .local_addr()
+        .context("shared TCP listener local_addr")?;
+
+    Ok((
+        local_addr,
+        SharedTcpRegistration {
+            port,
+            listen_key: bind_addr,
+            ufrag: local_ufrag,
+        },
+    ))
+}
+
+async fn dispatch_incoming(
+    mut stream: TcpStream,
+    peer_addr: SocketAddr,
+    port: Arc<SharedTcpPort>,
+) -> Result<()> {
+    let first_packet = read_tcp_framed_packet(&mut stream).await?;
+    let ufrag = peer_ufrag_from_binding_request(&first_packet)
+        .ok_or_else(|| anyhow!("first TCP frame is not a STUN binding with USERNAME"))?;
+
+    let inner = {
+        let sessions = port.sessions.lock();
+        sessions
+            .get(&ufrag)
+            .and_then(|weak| weak.upgrade())
+    };
+
+    let inner = inner.ok_or_else(|| anyhow!("no ICE session registered for ufrag {ufrag}"))?;
+    let listen_addr = port.listener.local_addr()?;
+
+    attach_demuxed_tcp_stream(inner, stream, peer_addr, listen_addr, first_packet).await;
+    Ok(())
+}
+
+async fn read_tcp_framed_packet(stream: &mut TcpStream) -> Result<Vec<u8>> {
+    let mut len_buf = [0u8; 2];
+    stream
+        .read_exact(&mut len_buf)
+        .await
+        .context("read TCP STUN frame length")?;
+    let len = u16::from_be_bytes(len_buf) as usize;
+    if len == 0 || len > MAX_STUN_MESSAGE {
+        bail!("invalid TCP STUN frame length {len}");
+    }
+    let mut buf = vec![0u8; len];
+    stream
+        .read_exact(&mut buf)
+        .await
+        .context("read TCP STUN frame body")?;
+    Ok(buf)
+}
+
+/// USERNAME on an inbound Binding request is `peer-ufrag:own-ufrag` from the sender.
+/// For a browser connecting to our passive listener, peer-ufrag is our local ufrag.
+fn peer_ufrag_from_binding_request(data: &[u8]) -> Option<String> {
+    let decoded = StunMessage::decode(data).ok()?;
+    if decoded.class != StunClass::Request || decoded.method != StunMethod::Binding {
+        return None;
+    }
+    let username = username_from_stun_bytes(data)?;
+    let (peer, _own) = username.split_once(':')?;
+    Some(peer.to_string())
+}
+
+fn username_from_stun_bytes(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 20 {
+        return None;
+    }
+    let length = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
+    if length + 20 != bytes.len() {
+        return None;
+    }
+    let mut offset = 20;
+    while offset + 4 <= bytes.len() {
+        let typ = u16::from_be_bytes([bytes[offset], bytes[offset + 1]]);
+        let len = u16::from_be_bytes([bytes[offset + 2], bytes[offset + 3]]) as usize;
+        offset += 4;
+        if offset + len > bytes.len() {
+            break;
+        }
+        if typ == 0x0006 {
+            let value = &bytes[offset..offset + len];
+            return std::str::from_utf8(value).ok().map(str::to_string);
+        }
+        offset += len;
+        offset += (4 - (len % 4)) % 4;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transports::ice::stun::random_bytes;
+
+    #[test]
+    fn extracts_peer_ufrag_from_binding_username() {
+        let tx_id = random_bytes::<12>();
+        let mut msg = StunMessage::binding_request(tx_id, Some("rustrtc"));
+        msg.attributes
+            .push(StunAttribute::Username("serverUfrag:clientUfrag".into()));
+        let bytes = msg.encode(None, false).unwrap();
+        assert_eq!(
+            peer_ufrag_from_binding_request(&bytes).as_deref(),
+            Some("serverUfrag")
+        );
+    }
+}


### PR DESCRIPTION
When tcp_port_range_start equals tcp_port_range_end, multiple PeerConnections register on one process-wide TcpListener. Incoming connections are demuxed by the server ufrag in the first STUN Binding request USERNAME attribute, enabling concurrent WHEP sessions on a single TCP port such as 8000.