### PR TITLE
fix(ice): honor controlling agent's USE-CANDIDATE nomination on controlled side

### DIFF
--- a/src/transports/ice/mod.rs
+++ b/src/transports/ice/mod.rs
@@ -1843,6 +1843,15 @@ async fn perform_connectivity_checks_async(inner: Arc<IceTransportInner>) {
         // Controlled side: select best pair but don't nominate.
         // nomination_complete is signalled when we receive USE-CANDIDATE
         // from the controlling agent.
+        //
+        // Once the peer has nominated a pair, that choice is authoritative
+        // and this selection must not run again: check rounds re-triggered
+        // by late (e.g. peer-reflexive) candidates would otherwise stomp the
+        // nominated pair with a locally-preferred one the peer never chose.
+        if inner.nomination_complete.borrow().is_some() {
+            debug!("ICE checks complete (controlled): keeping peer-nominated pair");
+            return;
+        }
         let pair = &successful_pairs[0];
         *inner.selected_pair.lock() = Some(pair.clone());
         let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
@@ -2324,23 +2333,22 @@ async fn handle_stun_request(
             if matches!(sender, IceSocketWrapper::TcpStream(_, _, _)) {
                 return;
             }
-            // RFC 8445 §7.3.1.5: once a pair is already nominated, subsequent
+            // RFC 8445 §7.3.1.5: once a pair has been nominated, subsequent
             // USE-CANDIDATE (e.g. keepalives from other candidates) must not
             // trigger re-nomination.  Guard here to prevent pair_monitor churn.
-            if inner.selected_pair.lock().is_some() {
-                if inner.nomination_complete.borrow().is_none() {
-                    trace!(
-                        "Controlled agent: pair already selected, signalling nomination_complete via UseCandidate from {}",
-                        addr
-                    );
-                    let _ = inner.nomination_complete.send(Some(true));
-                } else {
-                    trace!(
-                        "Controlled agent ignoring UseCandidate from {} – pair already nominated",
-                        addr
-                    );
-                }
+            if inner.nomination_complete.borrow().is_some() {
+                trace!(
+                    "Controlled agent ignoring UseCandidate from {} – pair already nominated",
+                    addr
+                );
             } else {
+                // The controlling agent's nomination is authoritative. A pair
+                // selected earlier by our own check completion is only
+                // provisional: on a multihomed host it can differ from the
+                // pair the peer actually validated - it may even be a path
+                // that only works in one direction (e.g. a source address the
+                // peer's network drops on the return leg) - so it must be
+                // replaced by the pair this request arrived on.
                 let local_addr: SocketAddr = match sender {
                     IceSocketWrapper::Udp(s) => s
                         .local_addr()
@@ -2373,13 +2381,27 @@ async fn handle_stun_request(
                 };
 
                 if let Some(pair) = pair {
-                    trace!(
-                        "Controlled agent selected pair via UseCandidate: {} -> {}",
-                        pair.local.address, pair.remote.address
-                    );
-                    *inner.selected_pair.lock() = Some(pair.clone());
-                    let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
-                    publish_selected_socket(&inner, &pair, Some(sender));
+                    let already_selected = {
+                        let selected = inner.selected_pair.lock();
+                        selected.as_ref().is_some_and(|s| {
+                            s.local.address == pair.local.address
+                                && s.remote.address == pair.remote.address
+                        })
+                    };
+                    if already_selected {
+                        trace!(
+                            "Controlled agent: UseCandidate confirms already-selected pair {} -> {}",
+                            pair.local.address, pair.remote.address
+                        );
+                    } else {
+                        debug!(
+                            "Controlled agent selected pair via UseCandidate: {} -> {}",
+                            pair.local.address, pair.remote.address
+                        );
+                        *inner.selected_pair.lock() = Some(pair.clone());
+                        let _ = inner.selected_pair_notifier.send(Some(pair.clone()));
+                        publish_selected_socket(&inner, &pair, Some(sender));
+                    }
                     let _ = inner.state.send(IceTransportState::Connected);
                     let _ = inner.nomination_complete.send(Some(true));
                 } else {

--- a/src/transports/ice/tests.rs
+++ b/src/transports/ice/tests.rs
@@ -2762,6 +2762,23 @@ async fn use_candidate_no_renomination_after_nomination() -> Result<()> {
     .await
     .context("timed out waiting for ICE connection")??;
 
+    // Connected only means the controlled side picked a provisional pair;
+    // the controlling agent's USE-CANDIDATE (which may switch that pair)
+    // can still be in flight. Wait for actual nomination before sampling.
+    let mut nom_rx = t2.subscribe_nomination_complete();
+    timeout(Duration::from_secs(10), async {
+        loop {
+            if nom_rx.borrow_and_update().is_some() {
+                return Ok::<_, anyhow::Error>(());
+            }
+            if nom_rx.changed().await.is_err() {
+                anyhow::bail!("nomination channel closed");
+            }
+        }
+    })
+    .await
+    .context("timed out waiting for nomination")??;
+
     // 2. Record the nominated pair and subscribe to future pair changes.
     let nominated_pair = t2
         .get_selected_pair()


### PR DESCRIPTION
## Problem

The controlled agent's USE-CANDIDATE handler only adopts the nominated pair when no selected pair exists yet (`src/transports/ice/mod.rs`, `if inner.selected_pair.lock().is_some()`). The controlled side's own check-completion task races ahead and always sets a provisional pair first, so by the time the controlling agent's USE-CANDIDATE arrives, the nomination is reduced to signalling `nomination_complete` — the pair the peer actually nominated is never adopted.

Additionally, check rounds re-triggered by late peer-reflexive candidates re-run the controlled-side selection and replace the selected pair with a locally-preferred one **after** nomination, so even a correct selection could be stomped later.

RFC 8445 §8.1.1 requires the controlled agent to use the pair the controlling agent nominates; picking its own priority-sorted favorite instead is a spec violation.

## Real-world impact

On a multihomed host this causes hard-to-diagnose **one-way media**: the provisional pair can be an asymmetric path that only works in one direction. We hit this in production with a PBX server that has both public and overlay (Tailscale) interfaces, with browser (Chrome/JsSIP) peers:

- provisional pair chosen by the controlled server: `public-IPv6 → peer-overlay-ULA (fd7a:…)` — the return leg is silently dropped by the peer's WireGuard cryptokey routing (source address not in allowed-ips), while the forward leg happens to work
- the pair the browser actually nominated (over the overlay) was ignored
- result: inbound RTP arrived fine at the server, outbound RTP went into a blackhole — callee hears caller, caller hears silence

Log signature of the bug (two conflicting selections per call, the second one *after* `nomination completed`):

```
ICE checks complete. Selected pair: [2a01:…]:32919 -> [fd7a:…]:32836
ICE nomination completed successfully, starting DTLS
ICE checks complete. Selected pair: 178.104.47.91:35994 -> 100.104.0.18:36197
```

## Fix

1. **USE-CANDIDATE adopts the pair it arrived on while nomination is pending**, replacing any provisional selection. A redundant re-publish is skipped when the pair is unchanged (avoids spurious `selected_pair_notifier` churn). The existing guard against post-nomination re-nomination (keepalives from other candidates) is kept as-is.
2. **The controlled-side selection in the check-completion task stops running once nomination completed**, so late check rounds can no longer stomp the peer-nominated pair.

Verified in production: the provisional phantom pair is now replaced within ~7 ms by `Controlled agent selected pair via UseCandidate: …`, DTLS starts on the correct pair, the late check round logs `keeping peer-nominated pair`, and two-way audio works.

## Tests

- `use_candidate_no_renomination_after_nomination` sampled the selected pair right after `Connected`, i.e. while the first genuine nomination could still be in flight — with the fix, that first nomination may now (correctly) switch the pair, which the test misread as re-nomination. It now waits for `nomination_complete` before sampling. Its actual concern — a keepalive USE-CANDIDATE from another address must not re-nominate — is unchanged and still covered.
- 117 ICE tests pass on this branch. Two failures reproduce identically on unpatched `main` (pre-existing, not caused by this change): `test_nomination_race_under_high_packet_loss` (flaky, also flaky on the published 0.3.92 crate) and `repro_bug3_ice_reconnect_cycle_re_fires_track_event` (deterministic).

## Known limitation (unchanged behavior)

A genuinely new nomination after `nomination_complete` (e.g. ICE restart / network migration) is still ignored, as before — this PR only fixes the initial nomination being disregarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)